### PR TITLE
Add TypeScript definitions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@ coverage/
 hast-util-from-parse5.js
 hast-util-from-parse5.min.js
 *.html
+*.json
 *.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 coverage/
 hast-util-from-parse5.js
 hast-util-from-parse5.min.js
+*.html
+*.md

--- a/package.json
+++ b/package.json
@@ -24,16 +24,20 @@
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "types/index.d.ts"
   ],
+  "types": "types/index.d.ts",
   "dependencies": {
     "ccount": "^1.0.3",
+    "dtslint": "^3.5.2",
     "hastscript": "^5.0.0",
     "property-information": "^5.0.0",
     "web-namespaces": "^1.1.2",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "@types/parse5": "^5.0.2",
     "browserify": "^16.0.0",
     "is-hidden": "^1.0.0",
     "not": "^0.1.0",
@@ -46,6 +50,7 @@
     "tinyify": "^2.0.0",
     "to-vfile": "^6.0.0",
     "unist-util-visit": "^2.0.0",
+    "vfile": "^4.1.0",
     "xo": "^0.27.0"
   },
   "scripts": {
@@ -55,7 +60,8 @@
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test",
-    "test": "npm run format && npm run build && npm run test-coverage"
+    "test-types": "dtslint types",
+    "test": "npm run format && npm run build && npm run test-coverage && npm run test-types"
   },
   "prettier": {
     "tabWidth": 2,
@@ -72,7 +78,8 @@
       "guard-for-in": "off"
     },
     "ignores": [
-      "hast-util-from-parse5.js"
+      "hast-util-from-parse5.js",
+      "**/*.ts"
     ]
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "not": "^0.1.0",
     "nyc": "^15.0.0",
     "parse5": "^5.0.0",
-    "prettier": "^1.0.0",
+    "prettier": "^2.0.5",
     "remark-cli": "^7.0.0",
     "remark-preset-wooorm": "^6.0.0",
     "tape": "^4.0.0",
@@ -49,7 +49,7 @@
     "xo": "^0.27.0"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write \"**/*.js\" && xo --fix",
+    "format": "remark . -qfo && prettier --write . && xo --fix",
     "build-bundle": "browserify index.js -s hastUtilFromParse5 > hast-util-from-parse5.js",
     "build-mangle": "browserify index.js -p tinyify -s hastUtilFromParse5 > hast-util-from-parse5.min.js",
     "build": "npm run build-bundle && npm run build-mangle",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,15 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
+    "@types/parse5": "^5.0.2",
     "ccount": "^1.0.3",
     "hastscript": "^5.0.0",
     "property-information": "^5.0.0",
+    "vfile": "^4.1.0",
     "web-namespaces": "^1.1.2",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "@types/parse5": "^5.0.2",
     "browserify": "^16.0.0",
     "dtslint": "^3.5.2",
     "is-hidden": "^1.0.0",
@@ -50,7 +51,6 @@
     "tinyify": "^2.0.0",
     "to-vfile": "^6.0.0",
     "unist-util-visit": "^2.0.0",
-    "vfile": "^4.1.0",
     "xo": "^0.27.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "ccount": "^1.0.3",
-    "dtslint": "^3.5.2",
     "hastscript": "^5.0.0",
     "property-information": "^5.0.0",
     "web-namespaces": "^1.1.2",
@@ -39,6 +38,7 @@
   "devDependencies": {
     "@types/parse5": "^5.0.2",
     "browserify": "^16.0.0",
+    "dtslint": "^3.5.2",
     "is-hidden": "^1.0.0",
     "not": "^0.1.0",
     "nyc": "^15.0.0",

--- a/test/fixtures/attributes/index.json
+++ b/test/fixtures/attributes/index.json
@@ -22,10 +22,7 @@
               "tagName": "p",
               "properties": {
                 "id": "foo",
-                "className": [
-                  "bar",
-                  "baz"
-                ],
+                "className": ["bar", "baz"],
                 "dataQux": "quux"
               },
               "children": [],

--- a/test/fixtures/attributes/index.json
+++ b/test/fixtures/attributes/index.json
@@ -22,7 +22,10 @@
               "tagName": "p",
               "properties": {
                 "id": "foo",
-                "className": ["bar", "baz"],
+                "className": [
+                  "bar",
+                  "baz"
+                ],
                 "dataQux": "quux"
               },
               "children": [],

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ var fromParse5 = require('..')
 
 var join = path.join
 
-test('hast-util-from-parse5', function(t) {
+test('hast-util-from-parse5', function (t) {
   var file = vfile({contents: '<title>Hello!</title><h1>World!'})
 
   t.deepEqual(
@@ -346,17 +346,15 @@ test('hast-util-from-parse5', function(t) {
   t.end()
 })
 
-test('fixtures', function(t) {
+test('fixtures', function (t) {
   var base = join('test', 'fixtures')
 
-  fs.readdirSync(base)
-    .filter(not(hidden))
-    .forEach(each)
+  fs.readdirSync(base).filter(not(hidden)).forEach(each)
 
   t.end()
 
   function each(fixture) {
-    t.test(fixture, function(st) {
+    t.test(fixture, function (st) {
       var opts = {
         file: vfile.readSync(join(base, fixture, 'index.html')),
         out: join(base, fixture, 'index.json')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,55 @@
+// TypeScript Version: 3.5
+import {Node} from 'unist'
+import {Document} from 'parse5'
+import {VFile} from 'vfile'
+
+declare namespace hastUtilFromParse5 {
+  interface HastUtilFromParse5Options {
+    /**
+     * Whether the [*root*](https://github.com/syntax-tree/unist#root) of the
+     * [*tree*](https://github.com/syntax-tree/unist#tree) is in the `'html'` or `'svg'`
+     * space.
+     *
+     * If an element in with the SVG namespace is found in `ast`, `fromParse5`
+     * automatically switches to the SVG space when entering the element, and switches
+     * back when leaving.
+     *
+     * @default 'html'
+     */
+    space?: 'html' | 'svg'
+
+    /**
+     * [`VFile`](https://github.com/vfile/vfile), used to add
+     * [positional information](https://github.com/syntax-tree/unist#positional-information)
+     * to [*nodes*](https://github.com/syntax-tree/hast#nodes).
+     * If given, the [*file*](https://github.com/syntax-tree/unist#file) should have the
+     * original HTML source as its contents.
+     */
+    file?: VFile
+    /**
+     *
+     * Whether to add extra positional information about starting tags, closing tags,
+     * and attributes to elements.
+     *
+     * Note: not used without `file`.
+     *
+     * @default: false
+     */
+    verbose?: boolean
+  }
+}
+
+/**
+ * Transform [Parse5’s AST](https://github.com/inikulin/parse5/blob/master/packages/parse5/docs/tree-adapter/default/interface-list.md)
+ * to a [**hast**](https://github.com/syntax-tree/hast)
+ * [*tree*](https://github.com/syntax-tree/unist#tree).
+ *
+ * @param options If `options` is a [`VFile`](https://github.com/vfile/vfile), it’s treated
+ *                 as `{file: options}`.
+ */
+declare function hastUtilFromParse5(
+  ast: Document,
+  options?: hastUtilFromParse5.HastUtilFromParse5Options | VFile
+): Node
+
+export = hastUtilFromParse5

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,0 +1,11 @@
+import vfile = require('vfile')
+import parse5 = require('parse5')
+import fromParse5 = require('hast-util-from-parse5')
+
+const file = vfile()
+const ast = parse5.parse('', {sourceCodeLocationInfo: true})
+fromParse5(ast, file)
+fromParse5(ast, {file})
+fromParse5(ast, {space: 'html'})
+fromParse5(ast, {space: 'svg'})
+fromParse5(ast, {verbose: true})

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "hast-util-from-parse5": ["index.d.ts"]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "no-redundant-jsdoc": false,
+    "semicolon": false,
+    "whitespace": false
+  }
+}


### PR DESCRIPTION
~~Because of reasoning in unifiedjs/unified#45, all packages consuming these types need to add dependencies on `@types/node`, `@types/parse5`, and `unified`.~~