### PR TITLE
types: ensure location attrs exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -286,7 +286,7 @@ function createLocation(ctx, node, location) {
       let key
 
       for (key in location.attrs) {
-        if (own.call(location.attrs, key)) {
+        if (location.attrs && own.call(location.attrs, key)) {
           props[find(ctx.schema, key).property] = position(location.attrs[key])
         }
       }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript can't quite infer that `location.attr` is not undefined from the loop, this gives TS an extra hint.

<!--do not edit: pr-->
