### PR TITLE
Update hastscript to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/hast": "^3.0.0",
     "@types/unist": "^3.0.0",
     "devlop": "^1.0.0",
-    "hastscript": "^8.0.0",
+    "hastscript": "^9.0.0",
     "property-information": "^6.0.0",
     "vfile": "^6.0.0",
     "vfile-location": "^5.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -245,6 +245,34 @@ test('fromParse5', async function (t) {
       }
     )
   })
+
+  await t.test('should handle unknown attributes', async function () {
+    assert.deepEqual(
+      fromParse5(parseFragment('<button type="other" disabled>Hello</button>')),
+      {
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'button',
+            properties: {
+              type: 'other',
+              disabled: true
+            },
+            children: [
+              {
+                type: 'text',
+                value: 'Hello'
+              }
+            ]
+          }
+        ],
+        data: {
+          quirksMode: false
+        }
+      }
+    )
+  })
 })
 
 test('fixtures', async function (t) {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope,
  provide a general description of the changes, and remember, it’s up to you to
  convince us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Hastscript 8.x has a bug where `type="anything"` will result in incorrect parsed tree. 9.0.0 fixed this [here](https://github.com/syntax-tree/hastscript/commit/8a5f97e8b76fb593b38fc34c67ba0ef40f41f357)

Fixes: https://github.com/syntax-tree/hast-util-from-html/issues/8

<!--do not edit: pr-->
